### PR TITLE
fix: Internal Server Error when working with @koa/router

### DIFF
--- a/lib/koa-to-express.js
+++ b/lib/koa-to-express.js
@@ -21,6 +21,7 @@ module.exports = middlewares => {
     return (req, res, next) => {
 
         const ctx   = app.createContext(req, res);
+        ctx.matched = [];
 
         if (ctx.status === 200) {
             res.statusCode = 404;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/xingxingted/koa-to-express#readme",
   "devDependencies": {
+    "@koa/router": "^11.0.1",
     "codecov": "^2.2.0",
     "istanbul": "^1.1.0-alpha.1",
     "mocha": "^3.4.1",

--- a/test/koa-with-router-to-express.js
+++ b/test/koa-with-router-to-express.js
@@ -1,0 +1,46 @@
+const express = require('express');
+const Koa = require('koa');
+const {agent} = require('supertest');
+
+const Router = require('@koa/router');
+
+const k2e = require('..');
+
+const expressApp = express();
+const koaApp = new Koa();
+const router = new Router();
+
+router.get('/health', function (ctx, next) {
+    ctx.body = {
+        everything: 'is ok',
+    }
+})
+
+koaApp.use(router.routes()).use(router.allowedMethods());
+
+koaApp.use(async (ctx, next) => {
+    ctx.body = 'all paths are not matched!'
+})
+
+expressApp.use('/error', (req, res, next) => {
+    res.status(502);
+    next();
+});
+koaApp.middleware.forEach(middleware => expressApp.use(k2e(middleware)));
+
+const expressAgent = agent(expressApp);
+const koaAgent = agent(koaApp.callback());
+
+describe('Koa with router to Express', () => {
+    it('should response health when requesting /health', () => Promise.all([
+        expressAgent.get('/health').expect(200),
+        koaAgent.get('/health').expect(200)
+    ]).then(([{body: expressBody}, {body: koaBody}]) => expressBody.should.be.deepEqual(koaBody)));
+
+    // This test case is to reproduce an issue when working with @koa/router
+    it('should response not exists when no matching path found', () => Promise.all([
+        // Before Fix, the test case will be Error: expected 200 "OK", got 500 "Internal Server Error"
+        expressAgent.get('/not-exist').expect(200),
+        koaAgent.get('/not-exist').expect(200)
+    ]).then(([{body: expressBody}, {body: koaBody}]) => expressBody.should.be.deepEqual(koaBody)));
+});


### PR DESCRIPTION
你好！

这个非常有用，感谢开源分享！我发现当在和 @koa/router 一起使用时，在转换成 express 之后，如果访问不存在的路径，会报 Internal Server Error。 看了一下原因是 @koa/router 有一个对 ctx.matched 总是有值的假设，因此修复方法是在创建 ctx 时，初始化一个 array。

https://github.com/koajs/router/blob/master/lib/router.js#L489

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/3367820/178978123-a229b5ad-0b5d-42a3-a56b-bbbd634d1a3a.png">


这个修复已经验证有效，希望能够合并回源代码库，以帮助到其他使用者。谢谢！